### PR TITLE
BB-2056 ESLint upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,32 +19,7 @@ module.exports = {
         'commonjs': true,
         'mocha': true
     },
-    'ecmaFeatures': {
-        'arrowFunctions': true,
-        'binaryLiterals': true,
-        'blockBindings': true,
-        'classes': true,
-        'defaultParams': true,
-        'destructuring': true,
-        'forOf': true,
-        'generators': true,
-        'modules': true,
-        'objectLiteralComputedProperties': true,
-        'objectLiteralDuplicateProperties': true,
-        'objectLiteralShorthandMethods': true,
-        'objectLiteralShorthandProperties': true,
-        'octalLiterals': true,
-        'regexUFlag': true,
-        'regexYFlag': true,
-        'restParams': true,
-        'spread': true,
-        'superInFunctions': true,
-        'templateStrings': true,
-        'unicodeCodePointEscapes': true,
-        'globalReturn': true,
-        'jsx': true
-    },
-    rules: {
+    'rules': {
         'arrow-parens': [ 'error', 'always' ],
         'arrow-body-style': [ 'error', 'always'],
         'arrow-spacing': 'error',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     }
   ],
   "devDependencies": {
-    "eslint": "^3.8.1"
+    "eslint": "^4.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bayzat",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "Shareable ESLint-er config used in all bayzat projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Upgrade to the newest version of ESLint 4.16.0
- Remove deprecated `ecmaFeatures`
- Bump version to 2.0.0 as it's breaking change